### PR TITLE
Delete redundant white-space

### DIFF
--- a/src/main/java/com/squall1744/main.java
+++ b/src/main/java/com/squall1744/main.java
@@ -24,7 +24,6 @@ public class main {
 
             System.out.println(IOUtils.toString(entity.getContent(), StandardCharsets.UTF_8));
 
-
             EntityUtils.consume(entity);
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
Delete redundant white-space to save space